### PR TITLE
Update EditorConfig.json with missing language rules

### DIFF
--- a/src/Schema/EditorConfig.json
+++ b/src/Schema/EditorConfig.json
@@ -460,6 +460,24 @@
       "documentationLink": "https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#expression_level_csharp"
     },
     {
+      "name": "csharp_style_implicit_object_creation_when_type_is_apparent",
+      "description": "Prefer target-typed new expressions when created type is apparent.",
+      "values": [ true, false ],
+      "defaultValue": [ true ],
+      "severity": true,
+      "defaultSeverity": "suggestion",
+      "documentationLink": "https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0090"
+    },
+    {
+      "name": "csharp_prefer_static_local_function",
+      "description": "Prefer local functions to be marked static.",
+      "values": [ true, false ],
+      "defaultValue": [ true ],
+      "severity": true,
+      "defaultSeverity": "suggestion",
+      "documentationLink": "https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0062"
+    },
+    {
       "name": "csharp_preserve_single_line_blocks",
       "description": "Leave block on single line.",
       "values": [ true, false ],


### PR DESCRIPTION
Adds missing rules which currently are labeled as 'unknown' with this extension.

- https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0090
	- csharp_style_implicit_object_creation_when_type_is_apparent
- https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0062
	- csharp_prefer_static_local_function